### PR TITLE
fix word2vec repo url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_ALL ja_JP.UTF-8
 
 RUN yum install -y wget tar vi
 RUN yum install -y gcc make gcc-c++
-RUN yum install -y svn git patch
+RUN yum install -y git patch
 RUN yum install -y icu libicu-devel
 # CentOS7版のepelはRE2がはいっていなかったので、6版で。
 RUN rpm --import http://ftp.riken.jp/Linux/fedora/epel/RPM-GPG-KEY-EPEL
@@ -35,7 +35,7 @@ RUN wget http://www.chokkan.org/software/word2vec-multi/word2vec.local.tgz
 RUN tar -xzf word2vec.local.tgz
 
 # word2vec
-RUN svn checkout http://word2vec.googlecode.com/svn/trunk/ word2vec
+RUN git clone https://github.com/svn2github/word2vec.git
 RUN cd word2vec ; make ; \
     cp word2vec /usr/local/bin ; cp word2phrase /usr/local/bin ; \
     cp word-analogy /usr/local/bin ; cp distance /usr/local/bin ; \

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ https://github.com/naoa/string-splitter
 | MeCab     | 0.996 | --enable-utf8-only|
 | MeCab IPAdic | 2.7.0-20070801 |--with-charset=utf8|
 | GCC | 4.8.2-16 ||
-| word2vec | http://word2vec.googlecode.com/svn/trunk/ | |
+| word2vec | https://github.com/svn2github/word2vec.git | |
 | ICU | 50.1.2-11 ||
 | RE2 | 20130115-2 ||
 | WordNet | 3.0-21 ||


### PR DESCRIPTION
- word2vecのレポジトリがsvnからgitに移行していたので更新しました
- word2vec利用のために必要となっていたsvnがgitへの移行に伴い不要となったことから、インストール対象から取り除きました
