### PR TITLE
fix libicu loading error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ ENV LC_ALL ja_JP.UTF-8
 RUN yum install -y wget tar vi
 RUN yum install -y gcc make gcc-c++
 RUN yum install -y git patch
-RUN yum install -y icu libicu-devel
+# word2vec-calc利用にあたってはlibicu-4.2.xを必要とするため該当バージョンをインストール。
+RUN yum localinstall -y ftp://fr2.rpmfind.net/linux/centos/6.8/os/x86_64/Packages/libicu-4.2.1-14.el6.x86_64.rpm
+RUN yum localinstall -y ftp://fr2.rpmfind.net/linux/centos/6.8/os/x86_64/Packages/libicu-devel-4.2.1-14.el6.x86_64.rpm
 # CentOS7版のepelはRE2がはいっていなかったので、6版で。
 RUN rpm --import http://ftp.riken.jp/Linux/fedora/epel/RPM-GPG-KEY-EPEL
 RUN yum localinstall -y http://ftp-srv2.kddilabs.jp/Linux/distributions/fedora/epel/6/x86_64/epel-release-6-8.noarch.rpm

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ https://github.com/naoa/string-splitter
 | MeCab IPAdic | 2.7.0-20070801 |--with-charset=utf8|
 | GCC | 4.8.2-16 ||
 | word2vec | https://github.com/svn2github/word2vec.git | |
-| ICU | 50.1.2-11 ||
+| ICU | 42.1-14 ||
 | RE2 | 20130115-2 ||
 | WordNet | 3.0-21 ||
 | glib2 | 2.36.3-5 ||


### PR DESCRIPTION
## 変更概要

`word2vec-calc`を使用するにあたり、`libicuxx.so.42`が必要なようですが、現在の構成においては`libicuxx.so.50`がインストールされ、動作しないため、RPMパッケージを指定してインストールするように変更しました。

今回の変更内容が、このレポジトリ及び`word2vec-calc`の方針と合わないようであれば構わずRejectいただければと思います。
念のため、今回の変更方法以外に試みた方法を掲載いたしますので、ご参考いただければと思います。
## 修正前のエラー

`word2vec-calc`を呼び出そうとすると次のようなエラーが得られます。

`error while loading shared libraries: libicui18n.so.42: cannot open shared object file: No such file or directory`

次のコマンドによりlibicuのインストール状況を確認すると確かに`libicui18n.so.42`はありませんでした。

`$ls -l /usr/lib64/libicu*`

```
lrwxrwxrwx. 1 root root       20  7月 14 11:44 /usr/lib64/libicudata.so -> libicudata.so.50.1.2
lrwxrwxrwx. 1 root root       20  7月 14 11:44 /usr/lib64/libicudata.so.50 -> libicudata.so.50.1.2
-rwxr-xr-x. 1 root root 20789896 11月 20  2015 /usr/lib64/libicudata.so.50.1.2
lrwxrwxrwx. 1 root root       20  7月 14 11:44 /usr/lib64/libicui18n.so -> libicui18n.so.50.1.2
lrwxrwxrwx. 1 root root       20  7月 14 11:44 /usr/lib64/libicui18n.so.50 -> libicui18n.so.50.1.2
-rwxr-xr-x. 1 root root  2096056 11月 20  2015 /usr/lib64/libicui18n.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicuio.so -> libicuio.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicuio.so.50 -> libicuio.so.50.1.2
-rwxr-xr-x. 1 root root    57136 11月 20  2015 /usr/lib64/libicuio.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicule.so -> libicule.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicule.so.50 -> libicule.so.50.1.2
-rwxr-xr-x. 1 root root   359112 11月 20  2015 /usr/lib64/libicule.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libiculx.so -> libiculx.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libiculx.so.50 -> libiculx.so.50.1.2
-rwxr-xr-x. 1 root root    48080 11月 20  2015 /usr/lib64/libiculx.so.50.1.2
lrwxrwxrwx. 1 root root       20  7月 14 11:44 /usr/lib64/libicutest.so -> libicutest.so.50.1.2
lrwxrwxrwx. 1 root root       20  7月 14 11:44 /usr/lib64/libicutest.so.50 -> libicutest.so.50.1.2
-rwxr-xr-x. 1 root root    66840 11月 20  2015 /usr/lib64/libicutest.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicutu.so -> libicutu.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicutu.so.50 -> libicutu.so.50.1.2
-rwxr-xr-x. 1 root root   170680 11月 20  2015 /usr/lib64/libicutu.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicuuc.so -> libicuuc.so.50.1.2
lrwxrwxrwx. 1 root root       18  7月 14 11:44 /usr/lib64/libicuuc.so.50 -> libicuuc.so.50.1.2
-rwxr-xr-x. 1 root root  1539392 11月 20  2015 /usr/lib64/libicuuc.so.50.1.2
```
## 今回の修正内容以外に試みた内容

`libicuxx.so.42`を必要とされるのは`epel-release-6-8`を使用している関係かと推定し、また、現在は7系のepelにおいても`RE2`が利用可能であるため、`http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-7.noarch.rpm`のepelに変更した上でインストールを続けるかたちを取りました。

結果として、`RUN cd string-splitter ; make ; cp string-splitter /usr/local/bin`実行時に次のようなエラーになります。

```
In file included from /usr/include/c++/4.8.2/mutex:35:0,
                 from /usr/include/re2/re2.h:184,
                 from string-splitter.cpp:35:
/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
string-splitter.cpp:38:27: fatal error: google/gflags.h: No such file or directory
 #include <google/gflags.h>
                           ^
compilation terminated.
make: *** [string-splitter] Error 1
cp: cannot stat ‘string-splitter’: No such file or directory
```

`RUN cd string-splitter ; grep -l 'gcc' Makefile | xargs sed -e 's/gcc/gcc -std=c++11/g ; make ; cp string-splitter /usr/local/bin`のようにしてコンパイルオプションを有効にしようとしましたが、状況に変化が見られなかったため、今回の変更内容のかたちに落ち着かせています。
## 修正後の`libicu`バージョン

`$ls -l /usr/lib64/libicu*`

```
lrwxrwxrwx. 1 root root       18  7月 14 12:03 /usr/lib64/libicudata.so -> libicudata.so.42.1
lrwxrwxrwx. 1 root root       18  7月 14 12:03 /usr/lib64/libicudata.so.42 -> libicudata.so.42.1
-rwxr-xr-x. 1 root root 16035184  5月 11 00:18 /usr/lib64/libicudata.so.42.1
lrwxrwxrwx. 1 root root       18  7月 14 12:03 /usr/lib64/libicui18n.so -> libicui18n.so.42.1
lrwxrwxrwx. 1 root root       18  7月 14 12:03 /usr/lib64/libicui18n.so.42 -> libicui18n.so.42.1
-rwxr-xr-x. 1 root root  1660584  5月 11 00:18 /usr/lib64/libicui18n.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicuio.so -> libicuio.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicuio.so.42 -> libicuio.so.42.1
-rwxr-xr-x. 1 root root    49240  5月 11 00:18 /usr/lib64/libicuio.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicule.so -> libicule.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicule.so.42 -> libicule.so.42.1
-rwxr-xr-x. 1 root root   218600  5月 11 00:18 /usr/lib64/libicule.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libiculx.so -> libiculx.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libiculx.so.42 -> libiculx.so.42.1
-rwxr-xr-x. 1 root root    50504  5月 11 00:18 /usr/lib64/libiculx.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicutu.so -> libicutu.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicutu.so.42 -> libicutu.so.42.1
-rwxr-xr-x. 1 root root   129112  5月 11 00:18 /usr/lib64/libicutu.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicuuc.so -> libicuuc.so.42.1
lrwxrwxrwx. 1 root root       16  7月 14 12:03 /usr/lib64/libicuuc.so.42 -> libicuuc.so.42.1
-rwxr-xr-x. 1 root root  1376304  5月 11 00:18 /usr/lib64/libicuuc.so.42.1
```

```
icu-config --version
4.2.1
```
